### PR TITLE
fix: removed whitespace for eslint

### DIFF
--- a/source/binary/patternplate.js
+++ b/source/binary/patternplate.js
@@ -21,7 +21,7 @@ const defaults = {
 const cli = meow(`
 	Usage
 	$ patternplate [command=start] [options]
-	
+
 	Commands
 	  start   - start a patternplate instance in cwd
 	  console - execute a task in patternplate console


### PR DESCRIPTION
On build eslint would throw an error for the whitespace in patternplate.js