### PR TITLE
(WIP) feat: command for creating new patterns

### DIFF
--- a/source/binary/patternplate.js
+++ b/source/binary/patternplate.js
@@ -8,6 +8,7 @@ import {omitBy, isNull} from 'lodash';
 
 import patternplate from '../';
 import patternplateInit from '../library/init/index.js';
+import patternplateCreate from '../library/create/index.js';
 
 const defaults = {
 	'open': null,
@@ -89,6 +90,10 @@ async function main(command = 'start', options = {}, input = []) {
 	if (command === 'init') {
 		const [, path] = input;
 		await patternplateInit(path, settings);
+		return {mode: 'console'};
+	} else if (command === 'create') {
+		const [, id, ...other] = input;
+		await patternplateCreate(id, other);
 		return {mode: 'console'};
 	}
 

--- a/source/library/create/get-data.js
+++ b/source/library/create/get-data.js
@@ -1,0 +1,15 @@
+const defaultJson = {
+	'name': 'defaultPattern',
+	'displayName': 'defaultPattern',
+	'version': '0.1.0',
+	'patterns': {}
+};
+
+const defaultMarkdown = '### Description\nDefault description for pattern.';
+
+const defaultFiles = {
+	'index.jsx': '',
+	'index.less': ''
+};
+
+export default { defaultMarkdown, defaultJson, defaultFiles };

--- a/source/library/create/index.js
+++ b/source/library/create/index.js
@@ -1,0 +1,58 @@
+import path from 'path';
+import {writeFile} from 'mz/fs';
+import exists from 'path-exists';
+import mkdirp from 'mkdirp-promise';
+import ora from 'ora';
+
+import {
+	defaultJson,
+	defaultMarkdown,
+	defaultFiles
+} from './get-data';
+
+
+async function create(id, other) {
+	const spinner = ora().start();
+
+	let folder;
+	for (let option in other) {
+		if (other.hasOwnProperty(option)) {
+			const match = other[option].match(/path=([^\s]*)/i)[1];
+			if (match) {
+				folder = match;
+			}
+		}
+	}
+	const path = './patterns/' + (folder ? `${folder}/${id}` : id);
+
+	if (await exists(path)) {
+		spinner.text = ` Pattern with the name ${id} already exists`;
+		spinner.fail();
+		return;
+	}
+
+	spinner.text = ` Create pattern folder with id: ${id}`;
+	await mkdirp(path);
+
+	spinner.text = ` Create pattern files`;
+	await createJson(`${path}/pattern.json`, id);
+	await writeFile(`${path}/index.md`, defaultMarkdown);
+
+	for (let file in defaultFiles) {
+		if (defaultFiles.hasOwnProperty(file)) {
+			await writeFile(`${path}/${file}`, defaultFiles[file]);
+		}
+	}
+
+	spinner.text = ` Pattern with the name ${id} created`;
+	spinner.succeed();
+}
+
+async function createJson(path, id) {
+	const value = defaultJson;
+	value.name = id;
+	value.displayName = id;
+	await writeFile(path, JSON.stringify(value, null, '  '));
+}
+
+export default create;


### PR DESCRIPTION
WIP for #100.
A new pattern with default files can be created with the command:
`npm run start create ID path=FOLDER`
This would create the pattern folder inside FOLDER with the name ID.

Maybe we should change out the matchers for modifiers to use something like [minimist](https://github.com/substack/minimist) or [meow](https://github.com/sindresorhus/meow).

Todos:
- [ ] User config files
- [ ] Modifiers for changes to pattern.json (see #100)
