### PR TITLE
fix: fix wrong encoding argument to sander.readFile

### DIFF
--- a/source/library/init/get-readme-data.js
+++ b/source/library/init/get-readme-data.js
@@ -7,7 +7,7 @@ function increment(line) {
 
 export default async function getReadmeData(context = {}) {
 	const readmePath = path.resolve(__dirname, '../../documentation/first-steps.md');
-	const readmeSource = await sander.readFile(readmePath, 'utf-8');
+	const readmeSource = await sander.readFile(readmePath, { encoding: 'utf-8' });
 
 	const readmeLines = readmeSource
 		.split('\n')


### PR DESCRIPTION
According to the sander documentation the encoding must be passed as an object, not a string.

https://github.com/Rich-Harris/sander#fs-methods

This fixes #151.