### PR TITLE
fix(api): handle pattern modules the same on client and server

### DIFF
--- a/packages/api/demo.js
+++ b/packages/api/demo.js
@@ -106,7 +106,7 @@ function html(content, payload) {
             var element = document.querySelector('[data-patternplate-mount]');
             var data = JSON.parse(decodeURIComponent(document.querySelector('[data-patternplate-vault]').textContent));
             var component = components[data.artifact];
-            render.mount(component, element);
+            render.mount(component.default || component, element);
           })();
         </script>
       </body>


### PR DESCRIPTION
e76e875 added 'native support' for default exports but only for rendering. This PR mirrors the behaviour for mounting.